### PR TITLE
[FIX] NPC가 영역을 인식하지 못하는 문제 수정

### DIFF
--- a/ImGround/Assets/soungsoo/NPC asset/NpcMover.cs
+++ b/ImGround/Assets/soungsoo/NPC asset/NpcMover.cs
@@ -51,6 +51,7 @@ public class NpcMover
         this.agent = npcObject.GetComponent<NavMeshAgent>();
         if (agent == null)
             throw new Exception(string.Format("NPC 게임오브젝트 {0}의 NavMeshAgent를 찾을 수 없습니다!!", npcObject.name));
+        agent.areaMask = NPCAreaBitMask;
 
         this.npcObject = npcObject;
         this.maxDuration = maxDuration;


### PR DESCRIPTION
- 기존에는 NavMeshAgent가 전체 NavMesh를 탐색하게 설정됨
  그러나 npc NavMesh와 다른 NavMesh가 종종 연결되지 않고 오갈 수 없는 경우가 존재
  이 경우 NPC는 경로를 찾을 수 없음
   **-> agent는 npc Layer에서만 움직이도록 강제합니다.**