### PR TITLE
[FEAT] UI 표시 후 입력키 제한기능 + 아이템 프리팹에 포함시킬 ID 추가

### DIFF
--- a/ImGround/Assets/Piloto Studio/Readme/Scripts/Editor/ReadmeEditor.cs
+++ b/ImGround/Assets/Piloto Studio/Readme/Scripts/Editor/ReadmeEditor.cs
@@ -10,7 +10,6 @@ namespace ReadmeSystem.Editor
 
 
     [CustomEditor(typeof(Readme))]
-    [InitializeOnLoad]
     public class ReadmeEditor : UnityEditor.Editor
     {
 

--- a/ImGround/Assets/Prefabs/Item Test/Package.prefab
+++ b/ImGround/Assets/Prefabs/Item Test/Package.prefab
@@ -1,0 +1,97 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &187504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 489404}
+  - component: {fileID: 3376292}
+  - component: {fileID: 2309798}
+  - component: {fileID: 64885853780235542}
+  m_Layer: 0
+  m_Name: Package
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &489404
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 187504}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &2309798
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 187504}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: fa8eda4ec55ee1a4e99ca991c5828dbf, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &3376292
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 187504}
+  m_Mesh: {fileID: 4300000, guid: e37e995ad25e5f24eafcb3e64da1e695, type: 3}
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 187504}
+  m_IsPrefabParent: 1
+--- !u!64 &64885853780235542
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 187504}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_InflateMesh: 0
+  m_SkinWidth: 0.01
+  m_Mesh: {fileID: 43969006961911266, guid: 5dee8c6ad8c57a84583b51ac2e5b227d, type: 2}

--- a/ImGround/Assets/Prefabs/Item Test/Package.prefab.meta
+++ b/ImGround/Assets/Prefabs/Item Test/Package.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63ce515d69d8cc9448c864591416615c
+timeCreated: 1484281218
+licenseType: Store
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ImGround/Assets/Resources/ItemInfoManager.cs
+++ b/ImGround/Assets/Resources/ItemInfoManager.cs
@@ -62,6 +62,7 @@ public class ItemInfoManager
     {
         new ItemInfo(ItemIdEnum.TEST_NULL_ITEM, ImageIdEnum.ITEM_NULL, "TestNullItem", DEFAULT_COUNT, 0),
         new ItemInfo(ItemIdEnum.PACKAGE, ImageIdEnum.NULL, "짐 꾸러미", DEFAULT_COUNT, 0),
+        new ItemInfo(ItemIdEnum.MONEY, ImageIdEnum.NULL, "돈", DEFAULT_COUNT, 0),
 
         new ItemInfo(ItemIdEnum.MILK_PACK, ImageIdEnum.ITEM_MILK_PACK, "우유 팩", DEFAULT_COUNT, 1500),
         new ItemInfo(ItemIdEnum.MILK_BUCKET, ImageIdEnum.ITEM_MILK_BUCKET, "우유 양동이", DEFAULT_COUNT, 1000),

--- a/ImGround/Assets/Scripts/Data_Item/ItemPrefabID.cs
+++ b/ImGround/Assets/Scripts/Data_Item/ItemPrefabID.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+public class ItemPrefabID : MonoBehaviour
+{
+    public ItemIdEnum itemType = ItemIdEnum.TEST_NULL_ITEM;
+    public int amount = 1;
+    private ItemBundle itemData = null;
+
+    public void setItemData(ItemBundle item)
+    {
+        itemData = item;
+    }
+
+    public ItemBundle getItem()
+    {
+        if (itemData == null)
+            return new ItemBundle(itemType, amount, false);
+        else
+            return itemData;
+    }
+}

--- a/ImGround/Assets/Scripts/Data_Item/ItemPrefabID.cs.meta
+++ b/ImGround/Assets/Scripts/Data_Item/ItemPrefabID.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50beb603c3909474881dfb184299c728
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ImGround/Assets/Scripts/Enums/ItemIdEnum.cs
+++ b/ImGround/Assets/Scripts/Enums/ItemIdEnum.cs
@@ -12,6 +12,7 @@ public enum ItemIdEnum
 
     TEST_NULL_ITEM,
     PACKAGE,
+    MONEY,
 
     /*=============================
      *            Foods

--- a/ImGround/Assets/Scripts/InputManager.cs
+++ b/ImGround/Assets/Scripts/InputManager.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+public class InputManager
+{
+    public static bool onUI = false;
+
+    /// <summary>
+    /// UI가 켜진 상태에서는 입력을 무시한 입력 결과를 반환합니다.
+    /// </summary>
+    /// <returns></returns>
+    public static bool GetKey(KeyCode key)
+    {
+        if (!onUI)
+        {
+            return Input.GetKey(key);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// UI가 켜진 상태에서는 입력을 무시한 입력 결과를 반환합니다.
+    /// </summary>
+    /// <returns></returns>
+    public static bool GetKeyDown(KeyCode key)
+    {
+        if (!onUI)
+        {
+            return Input.GetKeyDown(key);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// UI가 켜진 상태에서는 입력을 무시한 입력 결과를 반환합니다.
+    /// </summary>
+    /// <returns></returns>
+    public static bool GetMouseButton(int button)
+    {
+        if (!onUI)
+        {
+            return Input.GetMouseButton(button);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// UI가 켜진 상태에서는 입력을 무시한 입력 결과를 반환합니다.
+    /// </summary>
+    /// <returns></returns>
+    public static bool GetMouseButtonUp(int button)
+    {
+        if (!onUI)
+        {
+            return Input.GetMouseButtonUp(button);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// UI가 켜진 상태에서는 입력을 무시한 입력 결과를 반환합니다.
+    /// </summary>
+    /// <returns></returns>
+    public static float GetAxis(string axisName)
+    {
+        if (!onUI)
+        {
+            return Input.GetAxis(axisName);
+        }
+        return 0.0f;
+    }
+
+    /// <summary>
+    /// UI가 켜진 상태에서는 입력을 무시한 입력 결과를 반환합니다.
+    /// </summary>
+    /// <returns></returns>
+    public static float GetAxisRaw(string axisName)
+    {
+        if (!onUI)
+        {
+            return Input.GetAxisRaw(axisName);
+        }
+        return 0.0f;
+    }
+
+    /// <summary>
+    /// UI가 켜진 상태에서는 입력을 무시한 입력 결과를 반환합니다.
+    /// </summary>
+    /// <returns></returns>
+    public static bool GetButton(string buttonName)
+    {
+        if (!onUI)
+        {
+            return Input.GetButton(buttonName);
+        }
+        return false;
+    }
+}

--- a/ImGround/Assets/Scripts/InputManager.cs.meta
+++ b/ImGround/Assets/Scripts/InputManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8cd6874cd8a4c4d4ca22aeafbb43fc08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ImGround/Assets/Scripts/PlayerBehavior.cs
+++ b/ImGround/Assets/Scripts/PlayerBehavior.cs
@@ -252,10 +252,23 @@ public class PlayerBehavior : MonoBehaviour
         // Destroy the picked-up item
         if (pickedItem != null)
         {
+            getItem(pickedItem.GetComponent<ItemPrefabID>()); // 주운 아이템의 인벤토리 처리
             pickedItem.transform.SetParent(null);
             pickedItem.gameObject.SetActive(false);
             //Destroy(pickedItem);
             pickedItem = null; // Reset the reference to the item
+        }
+    }
+
+    private void getItem(ItemPrefabID itemPrefabId)
+    {
+        if (itemPrefabId == null)
+        {
+            Debug.LogError("아이템을 추가할 수 없음 : 아이템 프리팹/오브젝트에 " + nameof(ItemPrefabID) + " 스크립트가 없습니다!");
+        }
+        else
+        {
+            InventoryManager.addItems(itemPrefabId.getItem());
         }
     }
 

--- a/ImGround/Assets/Scripts/UI/InGameViewBehavior.cs
+++ b/ImGround/Assets/Scripts/UI/InGameViewBehavior.cs
@@ -88,7 +88,10 @@ public class InGameViewBehavior : MonoBehaviour
     public void hideView(InGameViewMode mode)
     {
         if (this.mode == mode)
+        {
             this.mode = InGameViewMode.DEFAULT;
+            InputManager.onUI = false;
+        }
         switch (mode)
         {
             case InGameViewMode.SETTING:
@@ -130,6 +133,7 @@ public class InGameViewBehavior : MonoBehaviour
         TalkView.setActive(mode == InGameViewMode.TALK);
 
         this.mode = mode;
+        InputManager.onUI = (this.mode != InGameViewMode.DEFAULT);
     }
 
     public void toggleView(InGameViewMode mode)

--- a/ImGround/Assets/Scripts/UI/Shop/ShopBehavior.cs
+++ b/ImGround/Assets/Scripts/UI/Shop/ShopBehavior.cs
@@ -162,6 +162,7 @@ public class ShopBehavior : UIBehavior
     /// <param name="money"></param>
     public void onMoneyChanged(int money)
     {
-        displayBuyable(money);
+        if (currentShop != null)
+            displayBuyable(money);
     }
 }

--- a/ImGround/Assets/Scripts/UI/SystemManager/InventoryManager.cs
+++ b/ImGround/Assets/Scripts/UI/SystemManager/InventoryManager.cs
@@ -149,6 +149,24 @@ public class InventoryManager
     /// <returns></returns>
     public static bool addItems(ItemBundle items)
     {
+        // 시스템 처리 구분
+        if (items.item.itemId == ItemIdEnum.TEST_NULL_ITEM)
+        {
+            return true;
+        }
+        if (items.item.itemId == ItemIdEnum.PACKAGE)
+        {
+            if (items.item is ItemPackage)
+                addPackage((ItemPackage)items.item);
+            // 실패 처리 아직 안됨.
+            return true;
+        }
+        if (items.item.itemId == ItemIdEnum.MONEY)
+        {
+            changeMoney(items.count);
+            return true;
+        }
+
         bool added = false;
         for (int i = 0; i < INVENTORY_SIZE; i++)
         {


### PR DESCRIPTION
## 주요 기능 :

### UI 사용시 키, 마우스 입력 무시 기능 : InputManager
> - **반드시 충돌을 피하기 위해 "본인 담당 코드"에만 변경해주세용**
> - UI가 켜졌을 때 무시되어야 하는 사용자 입력 부분을 다음과 같이 변경해주세요!
> 
>   before : 
>   ![스크린샷 2024-11-21 220029](https://github.com/user-attachments/assets/498b47f6-aa2f-48bb-9be0-2a770043a874)
>   after : 
>   ![스크린샷 2024-11-21 220107](https://github.com/user-attachments/assets/dbc8a329-9b3d-417e-ab22-9ffbeb82169d)
> 
> - InputManager 클래스는 다음의 메소드 까지만 지원합니다. 지원하지 않는 경우에는 기존 Input 클래스를 그대로 사용해도 됩니다!
> 
>   ![스크린샷 2024-11-21 215921](https://github.com/user-attachments/assets/79f46f46-cfd4-4c6b-a320-5b23cb74545d)

---

### 아이템 프리팹/오브젝트에 ItemPrefabID 스크립트 추가하기 :
> - 아이템 오브젝트를 아이템으로 인식하기 위한 스크립트입니다! 다음과 같이 붙여주세요.
>   (아래 사진은 돈보따리/고기 아이템에 스크립트를 추가하는 사진입니다.)
> 
>   ![스크린샷 2024-11-21 220902](https://github.com/user-attachments/assets/fc3f5e9e-2cde-40c6-9fc6-b54ab783911e)
> - 아이템 종류와 수량을 등록해주세요.
>   (수량은 거의 대부분 1이며, 돈일 경우에는 금액을 써주세요!)
>
>   ![스크린샷 2024-11-21 220917](https://github.com/user-attachments/assets/bf4c65ce-2073-493f-9124-67a961b4579c)


---
## 기타 변경사항 :
- 에셋 내 불필요한 readme 표시기 제거(Piloto Studio - ReadmeEditor.cs)
- 돈 아이템 추가
- 추가할 아이템의 구분에 따라 다르게 처리하는 로직 추가(InventoryManager.cs)
- Shop UI가 사용되지 않는데도 업데이트 하려는 문제 수정(ShopBehavior.cs)